### PR TITLE
Explicitly declare delegate conformance

### DIFF
--- a/DACircularProgress/DACircularProgressView.h
+++ b/DACircularProgress/DACircularProgressView.h
@@ -8,7 +8,7 @@
 
 #import <UIKit/UIKit.h>
 
-@interface DACircularProgressView : UIView
+@interface DACircularProgressView : UIView <CAAnimationDelegate>
 
 @property(nonatomic, strong) UIColor *trackTintColor UI_APPEARANCE_SELECTOR;
 @property(nonatomic, strong) UIColor *progressTintColor UI_APPEARANCE_SELECTOR;


### PR DESCRIPTION
Fixes a warning in Trails. Must be declared in the public header as we set it as a delegate from the outside.
